### PR TITLE
Add backend FastAPI and frontend Nuxt scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Python
+__pycache__/
+*.py[cod]
+
+# Node
+node_modules/
+.DS_Store
+
+# Environment
+.env

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+import uvicorn
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello, world!"}
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -1,0 +1,3 @@
+export default defineNuxtConfig({
+    // Nuxt configuration
+})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "frontend",
+  "private": true,
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "start": "nuxt start"
+  },
+  "dependencies": {
+    "nuxt": "^3.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold `backend` with a minimal FastAPI app
- add `requirements.txt` for backend deps
- scaffold `frontend` with Nuxt config and package.json
- add a repo-wide `.gitignore`

## Testing
- `python3 -m pip install -r backend/requirements.txt`
- `python3 backend/main.py` (server started)
- `npm install` in `frontend/`

------
https://chatgpt.com/codex/tasks/task_e_688bb0554c9083228b5557e4cd25b002