### PR TITLE
Add routers and DB placeholders

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -1,0 +1,15 @@
+import os
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+asyncpg://user:pass@localhost/codexkids")
+
+engine = create_async_engine(DATABASE_URL, echo=True)
+
+AsyncSessionLocal = sessionmaker(
+    engine, expire_on_commit=False, class_=AsyncSession
+)
+
+async def get_session() -> AsyncSession:
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,16 @@
 from fastapi import FastAPI
 import uvicorn
 
+import users
+import projects
+
 app = FastAPI()
 
+app.include_router(users.router)
+app.include_router(projects.router)
+
 @app.get("/")
-def read_root():
+async def read_root():
     return {"message": "Hello, world!"}
 
 if __name__ == "__main__":

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,66 @@
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, JSON, Text
+from sqlalchemy.orm import relationship, declarative_base
+
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    email = Column(String(255), unique=True, nullable=False)
+    username = Column(String(50), unique=True, nullable=False)
+    age_group = Column(String(20))  # 'elementary', 'middle', 'high'
+    skill_level = Column(String(20), default="beginner")
+
+    # relationships
+    projects = relationship("Project", back_populates="owner")
+    learning_progress = relationship("LearningProgress", back_populates="user")
+
+class Project(Base):
+    __tablename__ = "projects"
+
+    id = Column(Integer, primary_key=True)
+    title = Column(String(200), nullable=False)
+    description = Column(Text)
+    owner_id = Column(Integer, ForeignKey("users.id"))
+    language = Column(String(20))
+    code_content = Column(JSON)  # store versioned code
+    visibility = Column(String(20), default="private")
+
+    # relationships
+    owner = relationship("User", back_populates="projects")
+    collaborators = relationship("ProjectCollaborator", back_populates="project")
+
+class LearningProgress(Base):
+    __tablename__ = "learning_progress"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    module_id = Column(String(50))
+    completion_percentage = Column(Integer, default=0)
+    last_accessed = Column(DateTime)
+    performance_metrics = Column(JSON)  # detailed metrics
+
+    # relationships
+    user = relationship("User", back_populates="learning_progress")
+
+class CodeExecution(Base):
+    __tablename__ = "code_executions"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    code = Column(Text)
+    language = Column(String(20))
+    execution_time = Column(DateTime)
+    result = Column(JSON)
+    errors = Column(JSON)
+    visualization_data = Column(JSON)  # data for visualization
+
+class ProjectCollaborator(Base):
+    __tablename__ = "project_collaborators"
+
+    id = Column(Integer, primary_key=True)
+    project_id = Column(Integer, ForeignKey("projects.id"))
+    user_id = Column(Integer, ForeignKey("users.id"))
+
+    project = relationship("Project", back_populates="collaborators")

--- a/backend/projects.py
+++ b/backend/projects.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from db import get_session
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+@router.get("/")
+async def list_projects(session: AsyncSession = Depends(get_session)):
+    # Placeholder: fetch projects from the database
+    return []
+
+@router.post("/")
+async def create_project(session: AsyncSession = Depends(get_session)):
+    # Placeholder: create a new project
+    return {"message": "project created"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+sqlalchemy
+asyncpg

--- a/backend/users.py
+++ b/backend/users.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from db import get_session
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+@router.get("/")
+async def list_users(session: AsyncSession = Depends(get_session)):
+    # Placeholder: fetch users from the database
+    return []
+
+@router.post("/")
+async def create_user(session: AsyncSession = Depends(get_session)):
+    # Placeholder: create a new user
+    return {"message": "user created"}


### PR DESCRIPTION
## Summary
- expand backend requirements to support database connections
- stub out FastAPI routers for users and projects
- include routers in main app
- add SQLAlchemy models and asynchronous session helper

## Testing
- `python -m compileall backend`
- `pip install -r backend/requirements.txt`
- `uvicorn main:app --port 9000` (manual run)

------
https://chatgpt.com/codex/tasks/task_e_688bbd6790c0832294a5d9ab456e656b